### PR TITLE
Final cleanup of LastPass module -- track account, more *print_ cleaning

### DIFF
--- a/modules/post/multi/gather/lastpass_creds.rb
+++ b/modules/post/multi/gather/lastpass_creds.rb
@@ -104,7 +104,17 @@ class Metasploit3 < Msf::Post
       password = clear_text_password(user, enc_pass)
       credentials_table << [account, browser, user, password]
     end
-    print_good credentials_table.to_s unless credentials.empty?
+    unless credentials.empty?
+      print_good credentials_table.to_s
+      path = store_loot(
+        "lastpass.creds",
+        "text/csv",
+        session,
+        credentials_table.to_csv,
+        nil,
+        "Decrypted LastPass Master Passwords"
+      )
+    end
   end
 
   # Returns a mapping of { Account => { Browser => paths } }


### PR DESCRIPTION
The end goal of this was to track the account from which the lastpass credentials were obtained, then I realized the decrypted LastPass master password wasn't being looted, and along the way I cleaned up a few other things.
